### PR TITLE
Adding devtool eval to better debug client side errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "webpack": "~1.12.0"
   },
   "scripts": {
+    "dev": "node ./Parse-Dashboard/index.js & webpack --config webpack/build.config.js --devtool eval-source-map --progress --watch",
     "dashboard": "node ./Parse-Dashboard/index.js & webpack --config webpack/build.config.js --progress --watch",
     "pig": "http-server ./PIG -p 4041 -s & webpack --config webpack/PIG.config.js --progress --watch",
     "build": "NODE_ENV=production webpack --config webpack/production.config.js && webpack --config webpack/PIG.config.js",


### PR DESCRIPTION
Source map debugging for client side errors like: #73.

Adding as separate a development dedicated script. 