### PR TITLE
Fix issues with arrays contiaining null or pointers to users. Fixes #105.

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -39,16 +39,10 @@ let BrowserCell = ({ type, value, hidden, width, current, onSelect, readonly, on
     content = dateStringUTC(value);
   } else if (type === 'Boolean') {
     content = value ? 'True' : 'False';
-  } else if (type === 'Array' || type === 'Object') {
-    if (type === 'Array') {
-      let _value = [];
-      value.forEach((val) => {
-        _value.push(val.constructor === Parse.Object ? val.toPointer() : val);
-      });
-      content = JSON.stringify(_value);
-    } else {
-      content = JSON.stringify(value);
-    }
+  } else if (type === 'Array') {
+    content = JSON.stringify(value.map(val => val instanceof Parse.Object ? val.toPointer() : val))
+  } else if (type === 'Object') {
+    content = JSON.stringify(value);
   } else if (type === 'File') {
     if (value.url()) {
       content = <a href={value.url()} target='_blank'><Pill value={getFileName(value)} /></a>;
@@ -85,7 +79,7 @@ let BrowserCell = ({ type, value, hidden, width, current, onSelect, readonly, on
       </div>
     );
   }
-  
+
   if (current) {
     classes.push(styles.current);
   }

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -202,9 +202,7 @@ export default class BrowserTable extends React.Component {
             value = '';
           } else if (type === 'Array') {
             if (value) {
-              value = value.map((val) => {
-                return val.constructor === Parse.Object ? val.toPointer() : val;
-              });              
+              value = value.map(val => val instanceof Parse.Object ? val.toPointer() : val);
             }
           }
           let wrapTop = Math.max(0, this.props.current.row * ROW_HEIGHT);


### PR DESCRIPTION
For pointers to users the constructor is Parse.User, not Parse.Object, so `instanceof` is necessary.