### PR TITLE
Use browserHistory from React Router 2 instead of createHashHistory

### DIFF
--- a/src/parse-interface-guide/routes.js
+++ b/src/parse-interface-guide/routes.js
@@ -5,13 +5,12 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import createHashHistory from 'history/lib/createHashHistory';
 import PIG               from 'parse-interface-guide/PIG.react';
 import React             from 'react';
-import { Router, Route } from 'react-router';
+import { browserHistory, Router, Route } from 'react-router';
 
 module.exports = (
-<Router history={createHashHistory()}>
+<Router history={browserHistory}>
   <Route path='/' component={PIG} />
   <Route path='/:component' component={PIG} />
 </Router>


### PR DESCRIPTION
Patch for PIG, per console warning

![screen shot 2016-03-09 at 10 38 24 am](https://cloud.githubusercontent.com/assets/21967/13643414/5cc9b534-e5e6-11e5-925b-c990f1688d06.png)
