### PR TITLE
Add an 'Add a Class' entry to the edit menu

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -561,7 +561,8 @@ export default class Browser extends DashboardView {
             onPointerClick={this.handlePointerClick.bind(this)}
             setRelation={this.setRelation.bind(this)}
             onAddColumn={this.showAddColumn.bind(this)}
-            onAddRow={this.addRow.bind(this)} />
+            onAddRow={this.addRow.bind(this)}
+            onAddClass={this.showCreateClass.bind(this)} />
         );
       }
     }

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -30,6 +30,7 @@ let BrowserToolbar = ({
   onFilterChange,
   onAddColumn,
   onAddRow,
+  onAddClass,
   onExport,
   onRemoveColumn,
   onDeleteRows,
@@ -78,6 +79,7 @@ let BrowserToolbar = ({
       <BrowserMenu title='Edit' icon='edit-solid'>
         <MenuItem text='Add a row' onClick={onAddRow} />
         <MenuItem text='Add a column' onClick={onAddColumn} />
+        <MenuItem text='Add a class' onClick={onAddClass} />
         <Separator />
         <MenuItem
           disabled={selectionLength === 0}


### PR DESCRIPTION
The data browser 'Edit' menu has related options like 'Add a Row' or 'Delete this class', so 'Add a class' is a natural addition.

![](https://cloud.githubusercontent.com/assets/180404/13645476/01576f44-e5e0-11e5-92a8-d9bc2fceaecb.gif)