### PR TITLE
Fix missing class counts when switching apps

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -84,8 +84,6 @@ export default class Browser extends DashboardView {
 
   componentWillReceiveProps(nextProps, nextContext) {
     if (this.context !== nextContext) {
-      nextProps.schema.dispatch(ActionTypes.FETCH)
-      .then(() => this.fetchCollectionCounts());
       let changes = {
         filters: new List(),
         data: null,
@@ -112,6 +110,8 @@ export default class Browser extends DashboardView {
       if (nextProps.params.className) {
         this.fetchData(nextProps.params.className, nextProps.location.query && nextProps.location.query.filters ? changes.filters : []);
       }
+      nextProps.schema.dispatch(ActionTypes.FETCH)
+      .then(() => this.fetchCollectionCounts());
     }
     if (!nextProps.params.className && nextProps.schema.data.get('classes')) {
       this.redirectToFirstClass(nextProps.schema.data.get('classes'));


### PR DESCRIPTION
The Parse Dashboard tracks a count of each Parse Class and displays it
in the data browser. When a user visits and app, then visits a different
app, then goes back to the first app, the counts don't display.

It turns out that the Parse.Promise polyfill is incorrect. While an
resolved Promise should always schedule a microtask, the Parse.Promise
polyfill makes it possible for a Promise to be executed immediately,
which seems to happen here when the network request is cached (jumping
back to a previously viewed application).

This fixes the bug by moving the promise execution after the setState
call that may clear `this.state.counts`. However, the more correct
solution would be to fix the polyfill in Parse-SDK-JS, or better yet,
use someone else's, like Forbes': https://github.com/then/promise

For more information about promise scheduling, see:
https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/