### PR TITLE
App name ellipsis

### DIFF
--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -112,6 +112,7 @@
 }
 
 .currentApp, .menuRow {
+  @include ellipsis();
   display: block;
   background: #094162;
   height: 48px;

--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -74,14 +74,14 @@ let AppCard = ({
 
   return <li onClick={canBrowse}>
     {icon ? <a className={styles.icon}><img src={icon} /></a> : null}
-    <CountsSection className={styles.glance} title='At a glance'>
-      <Metric number={dash(app.users, prettyNumber(app.users))} label='total users' />
-      <Metric number={dash(app.installations, prettyNumber(app.installations))} label='total installations' />
-    </CountsSection>
     <div className={styles.details}>
       <a className={styles.appname}>{app.name}</a>
       {versionMessage}
     </div>
+    <CountsSection className={styles.glance} title='At a glance'>
+      <Metric number={dash(app.users, prettyNumber(app.users))} label='total users' />
+      <Metric number={dash(app.installations, prettyNumber(app.installations))} label='total installations' />
+    </CountsSection>
   </li>
 }
 

--- a/src/dashboard/Apps/AppsIndex.scss
+++ b/src/dashboard/Apps/AppsIndex.scss
@@ -103,7 +103,7 @@
   margin: 0 auto;
 
   li {
-    display: block;
+    display: flex;
     cursor: pointer;
     background: #193040;
     border-radius: 5px;
@@ -130,13 +130,15 @@
 
 .appname {
   @include ellipsis();
+  width: 100%;
   display: inline-block;
   font-size: 22px;
   color: white;
 }
 
 .details {
-  @include ellipsis();
+  flex: auto;
+  overflow: hidden;
   padding: 9px 0;
   color: #788c97;
   font-size: 12px;
@@ -156,7 +158,7 @@
 }
 
 .glance {
-  float: right;
+  flex: 0 0 auto;
   padding: 10px 12px;
   border-left: 1px solid #1e3b4d;
 }


### PR DESCRIPTION
I know the only thing discussed before was ellipsis in the sidebar, but ellipsis on the app index page were broken too. So I fixed both.

The commit fixing the app index page depends on flexbox. Hopefully this isn't a problem, since I expect that we only care about targeting modern browsers, but I'm open to discussing alternate solutions if we can't use flexbox.

# Before

![selection_023](https://cloud.githubusercontent.com/assets/180404/13688581/af91d52a-e6d7-11e5-9063-5d93b37c62ba.png)
![selection_026](https://cloud.githubusercontent.com/assets/180404/13688585/b46c7686-e6d7-11e5-9b55-f3a3d40a20ec.png)

# After

![selection_024](https://cloud.githubusercontent.com/assets/180404/13688589/bc57ce68-e6d7-11e5-867e-e814c3ffbeef.png)
![selection_025](https://cloud.githubusercontent.com/assets/180404/13688591/be1b2c2c-e6d7-11e5-8918-e9ae565d4b41.png)
![selection_027](https://cloud.githubusercontent.com/assets/180404/13688600/c0f8e7c2-e6d7-11e5-961c-92b7d8051744.png)