### PR TITLE
Updating error message handling.

### DIFF
--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -156,7 +156,7 @@ class Dashboard extends React.Component {
               return Parse.Promise.as(app);
             } else {
               app.serverInfo = {
-                error: 'unknown error',
+                error: error.message || 'unknown error',
                 enabledFeatures: {},
                 parseServerVersion: "unknown"
               }


### PR DESCRIPTION
Specifically with case of parse-server missing masterkey in mind.

I'm hoping this will alleviate users that haven't configured their parse server with a masterKey. I'm sure we can try to update other things to make it clearer but one step fwd.