### PR TITLE
adds polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-core": "~5.8.12",
     "babel-loader": "~5.3.0",
     "babel-plugin-remove-proptypes": "~1.0.0",
+    "babel-polyfill": "^6.7.2",
     "babel-runtime": "~5.8.25",
     "css-loader": "~0.18.0",
     "file-loader": "^0.8.5",

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -12,6 +12,7 @@ import Parse           from 'parse';
 import React           from 'react';
 import ReactDOM        from 'react-dom';
 import Dashboard       from './Dashboard';
+import 'babel-polyfill';
 
 require('stylesheets/fonts.scss');
 installDevTools(Immutable);


### PR DESCRIPTION
Adds polyfills for old browsers:

### build, minified
#### Without polyfills
dashboard.bundle.js  1.11 MB       0  [emitted]  dashboard

#### With polyfills
dashboard.bundle.js  1.19 MB       0  [emitted]  dashboard

### dev:
#### without polyfills
dashboard.bundle.js  8.87 MB       0  [emitted]  dashboard

#### with polyfills
dashboard.bundle.js   9.6 MB       0  [emitted]  dashboard

The impact on production server is negligible 

fixes #166 