### PR TITLE
Add support for relation's count in toolbar details

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -58,6 +58,7 @@ export default class Browser extends DashboardView {
       newObject: null,
 
       lastError: null,
+      relationCount: 0,
     };
   }
 
@@ -258,6 +259,11 @@ export default class Browser extends DashboardView {
     query.find({ useMasterKey: true }).then((data) => this.setState({ data: data, lastMax: 200 }));
   }
 
+  fetchRelationCount(relation) {
+    let p = this.context.currentApp.getRelationCount(relation);
+    p.then((count) => this.setState({ relationCount: count }));
+  }
+
   fetchNextPage() {
     if (!this.state.data) {
       return null;
@@ -327,8 +333,12 @@ export default class Browser extends DashboardView {
   setRelation(relation) {
     this.setState({
       relation: relation,
+      relationCount: 0,
       selection: {},
-    }, () => this.fetchData(relation, this.state.filters));
+    }, () => { 
+      this.fetchData(relation, this.state.filters);
+      this.fetchRelationCount(relation);      
+    });
   }
 
   handlePointerClick({ className, id }) {
@@ -541,7 +551,7 @@ export default class Browser extends DashboardView {
 
         browser = (
           <DataBrowser
-            count={this.state.counts[className]}
+            count={this.state.relation ? this.state.relationCount : this.state.counts[className]}
             perms={this.state.clp[className]}
             schema={schema}
             userPointers={userPointers}

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -50,10 +50,8 @@ let BrowserToolbar = ({
       } else {
         details.push(prettyNumber(count) + ' objects');
       }
-    }
-    else {
-      details.push('count unknown');
-    }
+  }
+
   if (!relation) {    
     if (perms && !hidePerms) {
       let read = perms.get && perms.find && perms.get['*'] && perms.find['*'];

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -44,14 +44,17 @@ let BrowserToolbar = ({
 }) => {
   let selectionLength = Object.keys(selection).length;
   let details = [];
-  if (!relation) {
-    if (count !== undefined) {
+  if (count !== undefined) {
       if (count === 1) {
         details.push('1 object');
       } else {
         details.push(prettyNumber(count) + ' objects');
       }
     }
+    else {
+      details.push('count unknown');
+    }
+  if (!relation) {    
     if (perms && !hidePerms) {
       let read = perms.get && perms.find && perms.get['*'] && perms.find['*'];
       let write = perms.create && perms.update && perms.delete && perms.create['*'] && perms.update['*'] && perms.delete['*'];

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -202,6 +202,13 @@ export default class ParseApp {
     return p;
   }
 
+  getRelationCount(relation) {
+    this.setParseKeys();
+    // let p = Parse.Promise.as(123); //
+    let p = relation.query().count({ useMasterKey: true });
+    return p;
+  }
+
   getAnalyticsRetention(time) {
     time = Math.round(time.getTime() / 1000);
     return AJAX.abortableGet('/apps/' + this.slug + '/analytics_retention?at=' + time);

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -204,7 +204,6 @@ export default class ParseApp {
 
   getRelationCount(relation) {
     this.setParseKeys();
-    // let p = Parse.Promise.as(123); //
     let p = relation.query().count({ useMasterKey: true });
     return p;
   }


### PR DESCRIPTION
Before objects count is cached with app schema and only shows for 'raw' classes presentations. This change adds support for objects count for relation presentations. The count itself is fetched every time Browser component gets new relation.