### PR TITLE
Added 'route' config option for mounting dashboard

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -17,6 +17,9 @@ packageJson('parse-dashboard', 'latest').then(latestPackage => {
 
 module.exports = function(config) {
   var app = express();
+  app.set('views', './');
+  app.set('view engine', 'jade');
+
   // Serve public files.
   app.use(express.static(path.join(__dirname,'public')));
 
@@ -83,7 +86,7 @@ module.exports = function(config) {
 
   // For every other request, go to index.html. Let client-side handle the rest.
   app.get('/*', function(req, res) {
-    res.sendFile(__dirname + '/index.html');
+    res.render('index', { route: config.route });
   });
 
   return app;

--- a/Parse-Dashboard/index.jade
+++ b/Parse-Dashboard/index.jade
@@ -1,0 +1,7 @@
+html
+    head
+        title Parse Dashboard
+    body
+        base(href=route)
+        #browser_mount
+        script(src="bundles/dashboard.bundle.js")

--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -91,11 +91,15 @@ p.then(config => {
 
   const app = express();
 
-  app.use(parseDashboard(config.data));
+  config.data.route = config.data.route || '/';
+  // add trailing slash
+  if (config.data.route.substr(-1) != '/') config.data.route += '/';
+
+  app.use(config.data.route, parseDashboard(config.data));
   // Start the server.
   app.listen(port);
 
-  console.log(`The dashboard is now available at http://localhost:${port}/`);
+  console.log(`The dashboard is now available at http://localhost:${port}${config.data.route}`);
 }, error => {
   if (error instanceof SyntaxError) {
     console.log('Your config file contains invalid JSON. Exiting.');

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "basic-auth": "^1.0.3",
     "commander": "^2.9.0",
     "express": "^4.13.4",
+    "jade": "^1.11.0",
     "json-file-plus": "^3.2.0",
     "package-json": "^2.3.1"
   },

--- a/src/components/Icon/Icon.react.js
+++ b/src/components/Icon/Icon.react.js
@@ -18,7 +18,7 @@ let Icon = ({ name, fill, width, height }) => {
   }
   return (
     <svg {...props} >
-      <use xlinkHref={`/bundles/sprites.svg#${name}`} />
+      <use xlinkHref={`bundles/sprites.svg#${name}`} />
     </svg>
   );
 };

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -117,7 +117,7 @@ class Dashboard extends React.Component {
   }
 
   componentDidMount() {
-    get('/parse-dashboard-config.json').then(({ apps, newFeaturesInLatestVersion = [] }) => {
+    get('parse-dashboard-config.json').then(({ apps, newFeaturesInLatestVersion = [] }) => {
       this.setState({ newFeaturesInLatestVersion });
       let appInfoPromises = apps.map(app => {
         if (app.serverURL.startsWith('https://api.parse.com/1')) {

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -14,7 +14,7 @@ module.exports = {
   context: path.join(__dirname, '../src'),
   output: {
     filename: '[name].bundle.js',
-    publicPath: '/bundles/'
+    publicPath: 'bundles/'
   },
   resolve: {
     root: [__dirname,path.join(__dirname, '../src'), path.join(__dirname, 'node_modules')]


### PR DESCRIPTION
Adding a 'route' property to the parse-dashboard-config will now run the dashboard on that route.

@flovilmart If you have a chance to play around with this I'd appreciate it.  You'll see most functionality works, but in developer tools there are requests which seem to be failing due to some root relative '/apps/' urls.  I'd love to find a better solution than changing all the root relative '/apps/' to 'apps/'.