### PR TITLE
Build on Deploy

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -15,7 +15,7 @@ packageJson('parse-dashboard', 'latest').then(latestPackage => {
   }
 });
 
-module.exports = function(config) {
+module.exports = function(config, allowInsecureHTTP) {
   var app = express();
   // Serve public files.
   app.use(express.static(path.join(__dirname,'public')));

--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -91,7 +91,7 @@ p.then(config => {
 
   const app = express();
 
-  app.use(parseDashboard(config.data));
+  app.use(parseDashboard(config.data, allowInsecureHTTP));
   // Start the server.
   app.listen(port);
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ In order to securely deploy the dashboard without leaking your apps master key, 
 
 The deployed dashboard detects if you are using a secure connection. If you are deploying the dashboard behind a load balancer or proxy that does early SSL termination, then the app won't be able to detect that the connection is secure. In this case, you can start the dashboard with the `--allowInsecureHTTP=1` option. You will then be responsible for ensureing that your proxy or load balancer only allows HTTPS.
 
+### Building on Deploy
+
+In order to build the project while deploying (opposed to locally, prior to deploy), you need to set the `POST_INSTALL_BUILD` environment variable to something on the environment it's being deployed to. This will compile the appropriate assets and copy them into the right place.
+
+Building on deploy has one major advantage, which is that you don't need to commit your built assets into your repo. It does mean, however, that everytime you deploy it will rebuild those assets, whether or not they changed.
+
 ## Run with Docker
 
 It is easy to use it with Docker. First build the image:

--- a/package.json
+++ b/package.json
@@ -29,28 +29,25 @@
     "LICENSE"
   ],
   "dependencies": {
-    "basic-auth": "^1.0.3",
-    "commander": "^2.9.0",
-    "express": "^4.13.4",
-    "json-file-plus": "^3.2.0",
-    "package-json": "^2.3.1"
-  },
-  "devDependencies": {
     "babel-core": "~5.8.12",
     "babel-loader": "~5.3.0",
     "babel-plugin-remove-proptypes": "~1.0.0",
     "babel-polyfill": "^6.7.2",
     "babel-runtime": "~5.8.25",
     "css-loader": "~0.18.0",
+    "babel-runtime": "~5.8.25",
+    "basic-auth": "^1.0.3",
+    "css-loader": "~0.18.0",
+    "commander": "^2.9.0",
+    "express": "^4.13.4",
     "file-loader": "^0.8.5",
-    "history": "~1.9.1",
-    "http-server": "~0.8.5",
     "immutable": "~3.7.5",
     "immutable-devtools": "~0.0.4",
-    "jest-cli": "^0.7.1",
+    "json-file-plus": "^3.2.0",
     "js-beautify": "~1.5.0",
     "marked": "^0.3.5",
     "node-sass": "~3.4.2",
+    "package-json": "^2.3.1",
     "parse": "1.6.14",
     "prismjs": "~1.2.0",
     "react": "^0.14.0",
@@ -62,17 +59,24 @@
     "sass-loader": "~3.1.2",
     "style-loader": "~0.12.3",
     "svg-prep": "~1.0.0",
-    "transform-jest-deps": "^2.1.0",
     "webpack": "~1.12.0"
   },
+  "devDependencies": {
+    "history": "~1.9.1",
+    "http-server": "~0.8.5",
+    "jest-cli": "^0.7.1",
+    "transform-jest-deps": "^2.1.0"
+   },
   "scripts": {
     "dev": "node ./Parse-Dashboard/index.js & webpack --config webpack/build.config.js --devtool eval-source-map --progress --watch",
     "dashboard": "node ./Parse-Dashboard/index.js & webpack --config webpack/build.config.js --progress --watch",
+    "dist": "npm run build && cp -r production/bundles Parse-Dashboard/public/bundles",
     "pig": "http-server ./PIG -p 4041 -s & webpack --config webpack/PIG.config.js --progress --watch",
     "build": "NODE_ENV=production webpack --config webpack/production.config.js && webpack --config webpack/PIG.config.js",
     "test": "NODE_PATH=./node_modules jest",
     "generate": "node scripts/generate.js",
     "prepublish": "webpack --config webpack/publish.config.js --progress",
+    "postinstall": "if [ -n \"$POST_INSTALL_BUILD\" ]; then npm run dist; fi",
     "start": "node ./Parse-Dashboard/index.js"
   },
   "bin": {


### PR DESCRIPTION
Moves all build deps to `dependencies` (opposed to `devDependencies`) so that the project can be built when deploying to production (like on Heroku, in this case). You enable this by setting the `POST_INSTALL_BUILD`.

Also fixes an issue introduced after splitting up the backend/static express apps where `allowInsecureHTTP` was being referenced while never being defined.