### PR TITLE
allow to set a custom mount path

### DIFF
--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -20,12 +20,14 @@ program.option('--appName [appName]', 'the name of the app you would like to man
 program.option('--config [config]', 'the path to the configuration file');
 program.option('--host [host]', 'the host to run parse-dashboard');
 program.option('--port [port]', 'the port to run parse-dashboard');
+program.option('--mountPath [mountPath]', 'the mount path to run parse-dashboard');
 program.option('--allowInsecureHTTP [allowInsecureHTTP]', 'set this flag when you are running the dashboard behind an HTTPS load balancer or proxy with early SSL termination.');
 
 program.parse(process.argv);
 
 const host = program.host || process.env.HOST || '0.0.0.0';
 const port = program.port || process.env.PORT || 4040;
+const mountPath = program.mountPath || process.env.MOUNT_PATH || '/';
 const allowInsecureHTTP = program.allowInsecureHTTP || process.env.PARSE_DASHBOARD_ALLOW_INSECURE_HTTP;
 
 let explicitConfigFileProvided = !!program.config;
@@ -93,10 +95,10 @@ p.then(config => {
 
   const app = express();
 
-  app.use(parseDashboard(config.data, allowInsecureHTTP));
+  app.use(mountPath, parseDashboard(config.data, allowInsecureHTTP));
   // Start the server.
   const server = app.listen(port, host, function () {
-    console.log(`The dashboard is now available at http://${server.address().address}:${server.address().port}/`);
+    console.log(`The dashboard is now available at http://${server.address().address}:${server.address().port}${mountPath}`);
   });
 }, error => {
   if (error instanceof SyntaxError) {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can launch the dashboard for an app with a single command by supplying an ap
 parse-dashboard --appId yourAppId --masterKey yourMasterKey --serverURL "https://example.com/parse" --appName optionalName
 ```
 
-You can then visit the dashboard in your browser at http://localhost:4040. You may set the host and port by supplying the --host and --port options to parse-dashboard. You can use anything you want as the app name, or leave it out in which case the app ID will be used.
+You can then visit the dashboard in your browser at http://localhost:4040. You may set the host, port and mount path by supplying the `--host`, `--port` and `--mountPath` options to parse-dashboard. You can use anything you want as the app name, or leave it out in which case the app ID will be used.
 
 If you want to manage multiple apps from the same dashboard, you can start the dashboard with a config file. For example, you could put your info into a file called `parse-dashboard-config.json` and then start the dashboard using `parse-dashboard --config parse-dashboard-config.json`. The file should match the following format:
 


### PR DESCRIPTION
Hello,

While we are at it, could we also add an option for the mount path ? This may be useful when running the dashboard behind an NGINX proxy, for instance.

These changes should enable one to set a mount path for the dashboard, e.g.

```
$ parse-dashboard --config myconfig.json --mountPath /dashboard

The dashboard is now available at http://0.0.0.0:4040/dashboard
```

As stated in #235, only mount paths that are not prefixes of `"parse-dashboard-config.json"` seem to work so far...