### PR TITLE
Fix warning in AppSelector (Fixes #104)

### DIFF
--- a/src/components/Sidebar/AppsSelector.react.js
+++ b/src/components/Sidebar/AppsSelector.react.js
@@ -66,13 +66,6 @@ export default class AppsSelector extends React.Component {
 
   render() {
     let position = this.state.position;
-    try {
-      //Workaround for an issue where the apps selector appears in the wrong place when the
-      //window is narrower than the sidebar break when opened.
-      position = Position.inWindow(ReactDOM.findDOMNode(this));
-    } catch (e) {
-      //Use the one from the state
-    }
     let popover = null;
     if (this.state.open) {
       let height = window.innerHeight - position.y;

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -23,29 +23,30 @@
   border-radius: 5px;
   width: 28px;
   height: 28px;
-  top: -999px;
-  left: 14px;
+  top: 10px;
+  left: 310px;
   opacity: 0;
   transition: left 0.5s ease-in, opacity 0.5s 0.5s ease-in;
 }
 
 @media (max-width: 980px) {
   .sidebar {
-    left: -300px;
+    left: 0;
   }
 
   .toggle {
+    left: 310px;
     top: 10px;
     opacity: 1;
   }
 
   body:global(.expanded) {
     .sidebar {
-      left: 0;
+      left: -300px;
     }
 
     .toggle {
-      left: 310px;
+      left: 10px;
     }
   }
 }


### PR DESCRIPTION
This also makes the sidebar open by default on narrow windows, as the original code causing the error was code that fixed a bug when the window was loaded while the sidebar was off-screen.