### PR TITLE
In some environment, req.sequre is always false even https

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -51,7 +51,8 @@ module.exports = function(config, allowInsecureHTTP) {
       req.connection.remoteAddress === '127.0.0.1' ||
       req.connection.remoteAddress === '::ffff:127.0.0.1' ||
       req.connection.remoteAddress === '::1';
-    if (!requestIsLocal && !req.secure && !allowInsecureHTTP) {
+    let isSecureConnection = req.secure || ((req.headers['x-forwarded-proto'] && req.headers['x-forwarded-proto'] == 'https') ? true : false);
+    if (!requestIsLocal && !isSecureConnection && !allowInsecureHTTP) {
       //Disallow HTTP requests except on localhost, to prevent the master key from being transmitted in cleartext
       return res.send({ success: false, error: 'Parse Dashboard can only be remotely accessed via HTTPS' });
     }


### PR DESCRIPTION
If req.secure is false then do 2nd check logic.
Because, in some environment, req.sequre is always false even https.

Thank you!!