### PR TITLE
Allow trust proxy if allowInsecureHTTP

### DIFF
--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -105,6 +105,7 @@ p.then(config => {
 
   const app = express();
 
+  if (allowInsecureHTTP) app.enable('trust proxy');
   app.use(mountPath, parseDashboard(config.data, allowInsecureHTTP));
   if(!configSSLKey || !configSSLCert){
     // Start the server.


### PR DESCRIPTION
`app.enable('trust proxy');` when you are running the dashboard behind an HTTPS load balancer or proxy.