### PR TITLE
Fix badge location

### DIFF
--- a/src/components/AppBadge/AppBadge.scss
+++ b/src/components/AppBadge/AppBadge.scss
@@ -21,6 +21,7 @@
   letter-spacing: 4px;
   width: 60px;
   padding-left: 3px;
+  float: right;
 }
 
 .prod {


### PR DESCRIPTION
At some point a bug got introduced that had them on the left, touching the app name.