### PR TITLE
Fix getLogs function

### DIFF
--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -99,14 +99,8 @@ export default class ParseApp {
    * since - only fetch lines since this Date
    */
   getLogs(level, since) {
-    let params = {
-      level: level,
-      n: 100,
-    };
-    if (since) {
-      params.startDate = since.getTime();
-    }
-    return this.apiRequest('GET', 'scriptlog', params, { useMasterKey: true });
+    let path = 'scriptlog?level=' + encodeURIComponent(level.toLowerCase()) + '&n=100' + (since?'&startDate=' + encodeURIComponent(since.getTime()):'');
+    return this.apiRequest('GET', path, {}, { useMasterKey: true });
   }
 
   /**


### PR DESCRIPTION
Right now the parse-dashboard is sending always the same 10 first info logs because no params are sent (it uses the default params from the parse-server).

Here the params are send in the querystring.

If someone has a better solution I'm interested :)