### PR TITLE
Fix past pushes page

### DIFF
--- a/src/dashboard/Push/PushIndex.react.js
+++ b/src/dashboard/Push/PushIndex.react.js
@@ -218,7 +218,7 @@ let formatStatus = (status) => {
 let getPushTime = (pushTime, updatedAt) => {
   let time = pushTime || updatedAt;
   let dateTime = new Date(time);
-  let isLocal = time.indexOf('Z') === -1;
+  let isLocal = typeof time === 'string' && time.indexOf('Z') === -1;
   let timeContent = DateUtils.yearMonthDayTimeFormatter(dateTime, !isLocal);
   let result  = [];
   if (isLocal) {


### PR DESCRIPTION
When updatedAt is a date object and pushTime is null, this crashes. Workaround by checking `typeof time`, since we don't have local time push in Parse Server anyway.