### PR TITLE
Sorting applications by name in the dashboard, #415

### DIFF
--- a/src/lib/AppsManager.js
+++ b/src/lib/AppsManager.js
@@ -18,6 +18,9 @@ const AppsManager = {
   },
 
   apps() {
+    appsStore.sort(function(app1, app2) {
+      return app1.name.localeCompare(app2.name);
+    });
     return appsStore;
   },
 


### PR DESCRIPTION
Always sorts before returning apps() - should probably live somewhere else but I'm unable to find a suitable location for it. Solves #415 