### PR TITLE
ConfigStore now uses the master key to fetch the Parse config

### DIFF
--- a/src/lib/stores/ConfigStore.js
+++ b/src/lib/stores/ConfigStore.js
@@ -22,8 +22,13 @@ function ConfigStore(state, action) {
   action.app.setParseKeys();
   switch (action.type) {
     case ActionTypes.FETCH:
-      return Parse.Config.get().then(({ attributes }) => {
-        return Map({ lastFetch: new Date(), params: Map(attributes) });
+      return Parse._request(
+        'GET',
+        'config',
+        {},
+        { useMasterKey: true }
+      ).then(({ params }) => {
+        return Map({ lastFetch: new Date(), params: Map(params) });
       });
     case ActionTypes.SET:
       return Parse._request(


### PR DESCRIPTION
The ConfigStore now uses the master key to fetch the Parse config. This is to prevent an issue
where the fetch command would not complete because of a `403 Unauthorized` error. This issue led to a bug on the dashboard's config page causing previously saved config entries to not load properly.