### PR TITLE
Add/relation viewer

### DIFF
--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
@@ -61,17 +61,17 @@ export default class DataBrowserHeaderBar extends React.Component {
       finalStyle.background = 'rgba(224,224,234,0.10)';
     }
     elements.push(
-      <div key='add' className={styles.addColumn} style={finalStyle}>
-        {readonly ?
-          null :
+      readonly ? null : (
+        <div key='add' className={styles.addColumn} style={finalStyle}>
           <a
             href='javascript:;'
             role='button'
             className={styles.addColumnButton}
             onClick={onAddColumn}>
             Add a new column
-          </a>}
-      </div>
+          </a>
+        </div>
+      )
     );
 
     return <div className={styles.bar}>{elements}</div>;

--- a/src/components/EmptyState/EmptyState.react.js
+++ b/src/components/EmptyState/EmptyState.react.js
@@ -35,7 +35,15 @@ let ctaButton = (cta, action) => {
   }
 }
 
-let EmptyState = ({ icon='', title='', description='', cta='', action=()=>{}}) => (
+let EmptyState = ({
+  icon='',
+  title='',
+  description='',
+  cta='',
+  action=() => {},
+  secondaryCta='',
+  secondaryAction=() => {},
+}) => (
   <div className={center}>
     <div className={styles.icon}>
       <Icon
@@ -47,6 +55,8 @@ let EmptyState = ({ icon='', title='', description='', cta='', action=()=>{}}) =
     <div className={styles.title}>{title}</div>
     <div className={styles.description}>{description}</div>
     {ctaButton(cta, action)}
+    {secondaryCta && ' '}
+    {ctaButton(secondaryCta, secondaryAction)}
   </div>
 );
 
@@ -67,6 +77,12 @@ EmptyState.propTypes = {
   ),
   action: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).describe(
     'An href link or a click handler that is forwarded to the CTA button.'
+  ),
+  secondaryCta: PropTypes.string.describe(
+    'The text that appears in the secondary CTA button.'
+  ),
+  secondaryAction: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).describe(
+    'An href link or a click handler that is forwarded to the secondary CTA button.'
   ),
 };
 

--- a/src/components/Toolbar/Toolbar.react.js
+++ b/src/components/Toolbar/Toolbar.react.js
@@ -15,7 +15,7 @@ const goBack = () => history.goBack();
 
 let Toolbar = (props) => {
   let backButton;
-  if (props.relation) {
+  if (props.relation || (props.filters && props.filters.size)) {
     backButton = (
       <a
         className={styles.iconButton}

--- a/src/components/Toolbar/Toolbar.react.js
+++ b/src/components/Toolbar/Toolbar.react.js
@@ -7,31 +7,59 @@
  */
 import PropTypes from 'lib/PropTypes';
 import React     from 'react';
+import Icon      from 'components/Icon/Icon.react';
 import styles    from 'components/Toolbar/Toolbar.scss';
+import history   from 'dashboard/history';
 
-let Toolbar = (props) => (
-  <div className={styles.toolbar}>
-    <div className={styles.title}>
-      <div className={styles.section}>{props.section}</div>
-      <div>
-        <span className={styles.subsection}>
-          {props.subsection}
-        </span>
-        <span className={styles.details}>
-          {props.details}
-        </span>
+const goBack = () => history.goBack();
+
+let Toolbar = (props) => {
+  let backButton;
+  if (props.relation) {
+    backButton = (
+      <a
+        className={styles.iconButton}
+        onClick={goBack}
+      >
+        <Icon
+          width={32}
+          height={32}
+          fill="#ffffff"
+          name="left-outline"
+        />
+      </a>
+    );
+  }
+  return (
+    <div className={styles.toolbar}>
+      <div className={styles.title}>
+        <div className={styles.nav}>
+          {backButton}
+        </div>
+        <div className={styles.titleText}>
+          <div className={styles.section}>{props.section}</div>
+          <div>
+            <span className={styles.subsection}>
+              {props.subsection}
+            </span>
+            <span className={styles.details}>
+              {props.details}
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className={styles.actions}>
+        {props.children}
       </div>
     </div>
-    <div className={styles.actions}>
-      {props.children}
-    </div>
-  </div>
-);
+  );
+};
 
 Toolbar.propTypes = {
   section: PropTypes.string,
   subsection: PropTypes.string,
-  details: PropTypes.string
+  details: PropTypes.string,
+  relation: PropTypes.object,
 };
 
 export default Toolbar;

--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -24,11 +24,25 @@
   }
 }
 
-
 .title {
   position: absolute;
   left: 14px;
   bottom: 10px;
+}
+
+.nav {
+  display: inline-block;
+}
+
+.iconButton {
+  display: block;
+  padding-top: 10px;
+  padding-right: 10px;
+  cursor: pointer;
+}
+
+.titleText {
+  display: inline-block;
 }
 
 .section {

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -212,6 +212,7 @@ class Dashboard extends React.Component {
 
           <Route path='browser' component={false ? SchemaOverview : Browser} /> //In progress features. Change false to true to work on this feature.
           <Route path='browser/:className' component={Browser} />
+          <Route path='browser/:className/:entityId/:relationName' component={Browser} />
 
           <Route path='cloud_code' component={CloudCode} />
           <Route path='cloud_code/*' component={CloudCode} />

--- a/src/dashboard/Data/Browser/AttachRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/AttachRowsDialog.react.js
@@ -1,20 +1,9 @@
 import React from 'react';
-import Modal from 'components/Modal/Modal.react';
+import FormModal from 'components/FormModal/FormModal.react';
 import Field from 'components/Field/Field.react';
 import Label from 'components/Label/Label.react';
 import TextInput from 'components/TextInput/TextInput.react';
-
-const styles = {
-  errorList: {
-    margin: '3px 6px',
-    padding: '3px',
-    color: 'red',
-    fontSize: '13px',
-    lineHeight: '1.4',
-    maxHeight: '300px',
-    overflow: 'auto',
-  },
-};
+import Parse from 'parse';
 
 export default class AttachRowsDialog extends React.Component {
   constructor(props) {
@@ -38,7 +27,16 @@ export default class AttachRowsDialog extends React.Component {
       if (!objectId) return;
       return [...resourceIds, objectId];
     }, []);
-    this.props.onConfirm(objectIds);
+    const promise = new Parse.Promise();
+    console.log(promise);
+    this.props.onConfirm(objectIds)
+    .then(promise.resolve)
+    .catch((error) => {
+      promise.reject({
+        error,
+      });
+    });
+    return promise;
   }
 
   render() {
@@ -46,40 +44,24 @@ export default class AttachRowsDialog extends React.Component {
       relation,
       onCancel,
       onConfirm,
-      errors,
     } = this.props;
-    let errorStatus;
-    if (errors) {
-      let errorList = [];
-      errors.forEach((error) => {
-        errorList.push((
-          <div>
-            * {error}
-          </div>
-        ));
-      });
-      errorStatus = (
-        <div style={styles.errorList}>
-          {errorList}
-        </div>
-      );
-    }
     return (
-      <Modal
-        type={Modal.Types.info}
+      <FormModal
         icon="plus"
         iconSize={40}
         title="Attach Rows"
-        subtitle={`Bring existing rows from ${relation.targetClassName}`}
-        onCancel={this.props.onCancel}
-        onConfirm={this.handleConfirm}
-        confirmText="Attach"
+        subtitle={`Attach existing rows from ${relation.targetClassName}`}
+        onClose={this.props.onCancel}
+        onSubmit={this.handleConfirm}
+        open
+        submitText="Attach"
+        inProgressText="Attaching ..."
       >
         <Field
           label={
             <Label
               text="objectIds"
-              description={`ids of ${relation.targetClassName} rows to attach`}
+              description={`IDs of ${relation.targetClassName} rows to attach`}
             />
           }
           input={
@@ -90,8 +72,7 @@ export default class AttachRowsDialog extends React.Component {
             />
           }
         />
-        {errorStatus}
-      </Modal>
+      </FormModal>
     );
   }
 }

--- a/src/dashboard/Data/Browser/AttachRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/AttachRowsDialog.react.js
@@ -4,9 +4,6 @@ import React from 'react';
 import Field from 'components/Field/Field.react';
 import Label from 'components/Label/Label.react';
 import TextInput from 'components/TextInput/TextInput.react';
-import { List, Map } from 'immutable';
-
-const BLACKLISTED_FILTERS = [];
 
 const styles = {
   errorList: {

--- a/src/dashboard/Data/Browser/AttachRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/AttachRowsDialog.react.js
@@ -1,6 +1,5 @@
-import * as Filters from 'lib/Filters';
-import Modal from 'components/Modal/Modal.react';
 import React from 'react';
+import Modal from 'components/Modal/Modal.react';
 import Field from 'components/Field/Field.react';
 import Label from 'components/Label/Label.react';
 import TextInput from 'components/TextInput/TextInput.react';

--- a/src/dashboard/Data/Browser/AttachRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/AttachRowsDialog.react.js
@@ -34,7 +34,12 @@ export default class AttachRowsDialog extends React.Component {
   }
 
   handleConfirm() {
-    this.props.onConfirm(this.state.objectIds);
+    const objectIds = this.state.objectIds.split(',').reduce((resourceIds, targetResourceId) => {
+      const objectId = targetResourceId && targetResourceId.trim();
+      if (!objectId) return;
+      return [...resourceIds, objectId];
+    }, []);
+    this.props.onConfirm(objectIds);
   }
 
   render() {
@@ -46,10 +51,10 @@ export default class AttachRowsDialog extends React.Component {
     } = this.props;
     let errorStatus;
     if (errors) {
-      const errorList = [];
+      let errorList = [];
       errors.forEach((error) => {
         errorList.push((
-          <div style={styles.errorText}>
+          <div>
             * {error}
           </div>
         ));
@@ -69,6 +74,7 @@ export default class AttachRowsDialog extends React.Component {
         subtitle={`Bring existing rows from ${relation.targetClassName}`}
         onCancel={this.props.onCancel}
         onConfirm={this.handleConfirm}
+        confirmText="Attach"
       >
         <Field
           label={

--- a/src/dashboard/Data/Browser/AttachRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/AttachRowsDialog.react.js
@@ -1,0 +1,95 @@
+import * as Filters from 'lib/Filters';
+import Modal from 'components/Modal/Modal.react';
+import React from 'react';
+import Field from 'components/Field/Field.react';
+import Label from 'components/Label/Label.react';
+import TextInput from 'components/TextInput/TextInput.react';
+import { List, Map } from 'immutable';
+
+const BLACKLISTED_FILTERS = [];
+
+const styles = {
+  errorList: {
+    margin: '3px 6px',
+    padding: '3px',
+    color: 'red',
+    fontSize: '13px',
+    lineHeight: '1.4',
+    maxHeight: '300px',
+    overflow: 'auto',
+  },
+};
+
+export default class AttachRowsDialog extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      objectIds: '',
+    };
+
+    this.handleObjectIdsChange = this.handleObjectIdsChange.bind(this);
+    this.handleConfirm = this.handleConfirm.bind(this);
+  }
+
+  handleObjectIdsChange(objectIds) {
+    this.setState({ objectIds });
+  }
+
+  handleConfirm() {
+    this.props.onConfirm(this.state.objectIds);
+  }
+
+  render() {
+    const {
+      relation,
+      onCancel,
+      onConfirm,
+      errors,
+    } = this.props;
+    let errorStatus;
+    if (errors) {
+      const errorList = [];
+      errors.forEach((error) => {
+        errorList.push((
+          <div style={styles.errorText}>
+            * {error}
+          </div>
+        ));
+      });
+      errorStatus = (
+        <div style={styles.errorList}>
+          {errorList}
+        </div>
+      );
+    }
+    return (
+      <Modal
+        type={Modal.Types.info}
+        icon="plus"
+        iconSize={40}
+        title="Attach Rows"
+        subtitle={`Bring existing rows from ${relation.targetClassName}`}
+        onCancel={this.props.onCancel}
+        onConfirm={this.handleConfirm}
+      >
+        <Field
+          label={
+            <Label
+              text="objectIds"
+              description={`ids of ${relation.targetClassName} rows to attach`}
+            />
+          }
+          input={
+            <TextInput
+              placeholder="ox0QZFl7eg, qs81Q72lTL, etc..."
+              value={this.state.objectIds}
+              onChange={this.handleObjectIdsChange}
+            />
+          }
+        />
+        {errorStatus}
+      </Modal>
+    );
+  }
+}

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -74,14 +74,12 @@ export default class Browser extends DashboardView {
     this.props.schema.dispatch(ActionTypes.FETCH)
     .then(() => this.handleFetchedSchema());
 
-    const { className, entityId, relationName } = this.props.params;
-
     if (!this.props.params.className && this.props.schema.data.get('classes')) {
       this.redirectToFirstClass(this.props.schema.data.get('classes'));
     } else if (this.props.params.className) {
       let filters = new List();
       if (this.props.location.query && this.props.location.query.filters) {
-        let queryFilters = JSON.parse(this.props.location.query.filters);
+        const queryFilters = JSON.parse(this.props.location.query.filters);
         queryFilters.forEach((filter) => {
           filters = filters.push(new Map(filter));
         });
@@ -379,7 +377,7 @@ export default class Browser extends DashboardView {
     } else {
       const source = this.props.params.className;
       const _filters = JSON.stringify(filters.toJSON());
-      const url = `browser/${source}` + (filters.size === 0 ? '' : `?filters=${(encodeURIComponent(_filters))}`);
+      const url = `browser/${source}${(filters.size === 0 ? '' : `?filters=${(encodeURIComponent(_filters))}`)}`;
       // filters param change is making the fetch call
       history.push(this.context.generatePath(url));
     }

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -270,6 +270,8 @@ export default class BrowserTable extends React.Component {
                 <EmptyState
                   title='No data to display'
                   description='This relation has no rows'
+                  cta='Add a row'
+                  action={this.props.onAddRow}
                   icon='files-solid' /> :
                 <EmptyState
                   title='No data to display'

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -17,6 +17,7 @@ import Parse                  from 'parse';
 import React                  from 'react';
 import StringEditor           from 'components/StringEditor/StringEditor.react';
 import styles                 from 'dashboard/Data/Browser/Browser.scss';
+import Button                 from 'components/Button/Button.react';
 
 const MAX_ROWS = 60; // Number of rows to render at any time
 const ROW_HEIGHT = 31;
@@ -239,16 +240,35 @@ export default class BrowserTable extends React.Component {
 
       let addRow = null;
       if (!this.props.newObject) {
-        addRow = (
-          <div className={styles.addRow}>
-            <a onClick={this.props.onAddRow}>
-              <Icon
-                name='plus-outline'
-                width={14}
-                height={14} />
-            </a>
-          </div>
-        );
+        if (this.props.relation) {
+          addRow = (
+            <div className={styles.addRow}>
+              <Button
+                onClick={this.props.onAddRow}
+                primary
+                value={`Create a ${this.props.relation.targetClassName} and attach`}
+              />
+              {' '}
+              <Button
+                onClick={this.props.onAttachRows}
+                primary
+                value={`Attach existing rows from ${this.props.relation.targetClassName}`}
+              />
+            </div>
+          );
+        } else {
+          addRow = (
+            <div className={styles.addRow}>
+              <a onClick={this.props.onAddRow}>
+                <Icon
+                  name='plus-outline'
+                  width={14}
+                  height={14}
+                />
+              </a>
+            </div>
+          );
+        }
       }
 
       if (this.props.newObject || this.props.data.length > 0) {
@@ -269,13 +289,15 @@ export default class BrowserTable extends React.Component {
               {this.props.relation ?
                 <EmptyState
                   title='No data to display'
-                  description='This relation has no rows'
-                  cta='Add a row'
+                  description='This relation has no rows. Attach existing rows or create row.'
+                  cta={`Create ${this.props.relation.targetClassName} and attach`}
                   action={this.props.onAddRow}
+                  secondaryCta={`Attach existing rows from ${this.props.relation.targetClassName}`}
+                  secondaryAction={this.props.onAttachRows}
                   icon='files-solid' /> :
                 <EmptyState
                   title='No data to display'
-                  description='Add a row to store an object in this class'
+                  description='Add a row to store an object in this class.'
                   icon='files-solid'
                   cta='Add a row'
                   action={this.props.onAddRow} />

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -72,11 +72,11 @@ let BrowserToolbar = ({
     menu = (
       <BrowserMenu title='Edit' icon='edit-solid'>
         <MenuItem
-          text="Add a row"
+          text={`Create ${relation.targetClassName} and attach`}
           onClick={onAddRow}
         />
         <MenuItem
-          text="Add existing row"
+          text="Attach existing row"
           onClick={onAttachRows}
         />
         <Separator />

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -37,6 +37,7 @@ let BrowserToolbar = ({
   onDropClass,
   onChangeCLP,
   onRefresh,
+  onAttachRows,
   hidePerms,
 
   enableDeleteAllRows,
@@ -73,6 +74,10 @@ let BrowserToolbar = ({
         <MenuItem
           text="Add a row"
           onClick={onAddRow}
+        />
+        <MenuItem
+          text="Add existing row"
+          onClick={onAttachRows}
         />
         <Separator />
         <MenuItem

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -53,7 +53,7 @@ let BrowserToolbar = ({
       }
   }
 
-  if (!relation) {    
+  if (!relation) {
     if (perms && !hidePerms) {
       let read = perms.get && perms.find && perms.get['*'] && perms.find['*'];
       let write = perms.create && perms.update && perms.delete && perms.create['*'] && perms.update['*'] && perms.delete['*'];
@@ -71,9 +71,15 @@ let BrowserToolbar = ({
     menu = (
       <BrowserMenu title='Edit' icon='edit-solid'>
         <MenuItem
+          text="Add a row"
+          onClick={onAddRow}
+        />
+        <Separator />
+        <MenuItem
           disabled={selectionLength === 0}
-          text={selectionLength === 1 && !selection['*'] ? 'Remove this row' : 'Remove these rows'}
-          onClick={() => onDeleteRows(selection)} />
+          text={selectionLength === 1 && !selection['*'] ? 'Detach this row' : 'Detach these rows'}
+          onClick={() => onDeleteRows(selection)}
+        />
       </BrowserMenu>
     );
   } else {
@@ -104,6 +110,7 @@ let BrowserToolbar = ({
   }
   return (
     <Toolbar
+      relation={relation}
       section={relation ? `Relation <${relation.targetClassName}>` : 'Class'}
       subsection={subsection}
       details={details.join(' \u2022 ')}

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -116,6 +116,7 @@ let BrowserToolbar = ({
   return (
     <Toolbar
       relation={relation}
+      filters={filters}
       section={relation ? `Relation <${relation.targetClassName}>` : 'Class'}
       subsection={subsection}
       details={details.join(' \u2022 ')}

--- a/src/dashboard/Data/Browser/DeleteRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/DeleteRowsDialog.react.js
@@ -55,7 +55,7 @@ export default class DeleteRowsDialog extends React.Component {
         type={Modal.Types.DANGER}
         icon='warn-outline'
         title={this.props.selection['*'] ? `${deleteText} all rows?` : (selectionLength === 1 ? `${deleteText} this row?` : `${deleteText} ${selectionLength} rows?`)}
-        subtitle={this.props.relation ? 'You need to delete origin record. This is reference.' : 'This action cannot be undone!'}
+        subtitle={this.props.relation ? 'You need to delete origin record. This is a reference.' : 'This action cannot be undone!'}
         disabled={!this.valid()}
         confirmText={`Yes, ${this.props.relation ? 'detach' : 'delete'}`}
         cancelText={'Never mind, don\u2019t.'}

--- a/src/dashboard/Data/Browser/DeleteRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/DeleteRowsDialog.react.js
@@ -49,14 +49,15 @@ export default class DeleteRowsDialog extends React.Component {
           } />
       );
     }
+    const deleteText = this.props.relation ? 'Detach' : 'Delete';
     return (
       <Modal
         type={Modal.Types.DANGER}
         icon='warn-outline'
-        title={this.props.selection['*'] ? 'Delete all rows?' : (selectionLength === 1 ? 'Delete this row?' : `Delete ${selectionLength} rows?`)}
-        subtitle='This action cannot be undone!'
+        title={this.props.selection['*'] ? `${deleteText} all rows?` : (selectionLength === 1 ? `${deleteText} this row?` : `${deleteText} ${selectionLength} rows?`)}
+        subtitle={this.props.relation ? 'You need to delete origin record. This is reference.' : 'This action cannot be undone!'}
         disabled={!this.valid()}
-        confirmText='Yes, delete.'
+        confirmText={`Yes, ${this.props.relation ? 'detach' : 'delete'}`}
         cancelText={'Never mind, don\u2019t.'}
         onCancel={this.props.onCancel}
         onConfirm={this.props.onConfirm}>


### PR DESCRIPTION
Sorry, I made some foolish mistakes previous pull request #446 .
So I resubmit this PR again.

`Browser` component
* shows go back button if relation viewer or filters applied(actually just hitting browser history back)

`Browser` component's relation viewer
* has route statement
* can attach new/existing(by id) row to the relation
* can refresh
* can filter