### PR TITLE
Added HTTPS Check for Heroku

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -74,7 +74,7 @@ module.exports = function(config, allowInsecureHTTP) {
       req.connection.remoteAddress === '127.0.0.1' ||
       req.connection.remoteAddress === '::ffff:127.0.0.1' ||
       req.connection.remoteAddress === '::1';
-    if (!requestIsLocal && !req.secure && !allowInsecureHTTP) {
+    if (!requestIsLocal && !req.secure && req.header('x-forwarded-proto') != 'https' && !allowInsecureHTTP) {
       //Disallow HTTP requests except on localhost, to prevent the master key from being transmitted in cleartext
       return res.send({ success: false, error: 'Parse Dashboard can only be remotely accessed via HTTPS' });
     }


### PR DESCRIPTION
(Thanks to http://jaketrent.com/post/https-redirect-node-heroku/)
When hosting on Heroku, it turns out the request.secure will always be false, even if the client requests over HTTPS.  Instead, Heroku adds an HTTP header 'x-forwarded-proto' specifying the protocol used ('http' or 'https').  For those on Heroku, this additional check will allow the HTTPs check to work.  For those not on Heroku (where this header doesn't exist), it won't do anything.