### PR TITLE
using mount path when mounted as express module

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -17,14 +17,15 @@ packageJson('parse-dashboard', 'latest').then(latestPackage => {
 });
 
 function getMount(req) {
-  let url = req.url;
-  let originalUrl = req.originalUrl;
-  var mountPathLength = req.originalUrl.length - req.url.length;
-  var mountPath = req.originalUrl.slice(0, mountPathLength);
-  if (!mountPath.endsWith('/')) {
-    mountPath += '/';
+  const url = req.url;
+  const originalUrl = req.originalUrl;
+  const mountPath = process.env.MOUNT_PATH || '';
+  const mountPathLength = req.originalUrl.length - req.url.length;
+  let mountPathLocal = req.originalUrl.slice(0, mountPathLength);
+  if (!mountPathLocal.endsWith('/')) {
+    mountPathLocal += '/';
   }
-  return mountPath;
+  return mountPath + mountPathLocal;
 }
 
 function checkIfIconsExistForApps(apps, iconsFolder) {


### PR DESCRIPTION
The dashboard did not use the MOUNT_PATH env var when used as express module.