### PR TITLE
Allow sorting by `createdAt` ascending

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -302,12 +302,19 @@ export default class Browser extends DashboardView {
 
   async fetchParseData(source, filters) {
     const query = queryFromFilters(source, filters);
-    if (this.state.ordering[0] === '-') {
-      query.descending(this.state.ordering.substr(1));
+    const sortDir = this.state.ordering[0] === '-' ? '-' : '+';
+    const field = this.state.ordering.substr(sortDir === '-' ? 1 : 0)
+
+    if (sortDir === '-') {
+      query.descending(field)
     } else {
-      query.ascending(this.state.ordering);
+      query.ascending(field)
     }
-    query.addDescending('createdAt');
+
+    if (field !== 'createdAt') {
+      query.addDescending('createdAt');
+    }
+
     query.limit(200);
     const data = await query.find({ useMasterKey: true });
     return data;


### PR DESCRIPTION
When attempting to sort by the `createdAt` column, we would still apply
the default sort ordering of `-createdAt`, meaning that we would specify
a sort order of `createdAt,-createdAt`. When Parse-Server gets a sort
order in which the same field appears more than once, it will use the
last entry for the field in its sorting. This means that the sort the
user has selected is overwritten by the default sort we apply.

We now check to see if the sort we are applying is already on the
`createdAt` field, and if so we do not apply the default ordering.

Fixes #447.