### PR TITLE
Made the encrypted passwords an option

### DIFF
--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -1,0 +1,33 @@
+function Authentication(validUsers, useEncryptedPasswords) {
+    this.validUsers = validUsers;
+    this.useEncryptedPasswords = useEncryptedPasswords || false;
+}
+
+Authentication.prototype.authenticate = function (userToTest) {
+  let bcrypt = require('bcryptjs');
+
+  var appsUserHasAccessTo = null;
+
+  //they provided auth
+  let isAuthenticated = userToTest &&
+    //there are configured users
+    this.validUsers &&
+    //the provided auth matches one of the users
+    this.validUsers.find(user => {
+      let isAuthenticated = userToTest.name == user.user &&
+                        (this.useEncryptedPasswords ? bcrypt.compareSync(userToTest.pass, user.pass) : userToTest.pass == user.pass);
+      if (isAuthenticated) {
+        // User restricted apps
+        appsUserHasAccessTo = user.apps || null;
+      }
+
+      return isAuthenticated
+    }) ? true : false;
+  
+  return {
+    isAuthenticated,
+    appsUserHasAccessTo
+  }
+}
+
+module.exports = Authentication;

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -61,6 +61,9 @@ module.exports = function(config, allowInsecureHTTP) {
     };
 
     const users = config.users;
+    const options = config.options || {
+      useEncryptedPasswords: false
+    };
 
     let auth = null;
     //If they provide auth when their config has no users, ignore the auth
@@ -95,8 +98,7 @@ module.exports = function(config, allowInsecureHTTP) {
       //the provided auth matches one of the users
       users.find(user => {
         let isAuthorized = user.user == auth.name &&
-                          (user.pass == auth.pass ||
-                           bcrypt.compareSync(auth.pass, user.pass));
+                          (options.useEncryptedPasswords ? bcrypt.compareSync(auth.pass, user.pass) : user.pass == auth.pass);
         if (isAuthorized) {
           // User restricted apps
           appsUserHasAccess = user.apps

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -61,9 +61,7 @@ module.exports = function(config, allowInsecureHTTP) {
     };
 
     const users = config.users;
-    const options = config.options || {
-      useEncryptedPasswords: false
-    };
+    const useEncryptedPasswords = config.useEncryptedPasswords ? true : false;
 
     let auth = null;
     //If they provide auth when their config has no users, ignore the auth
@@ -87,28 +85,15 @@ module.exports = function(config, allowInsecureHTTP) {
       return res.send({ success: false, error: 'Configure a user to access Parse Dashboard remotely' });
     }
 
-    let appsUserHasAccess = null;
-    let bcrypt = require('bcryptjs');
-
-    const successfulAuth =
-      //they provided auth
-      auth &&
-      //there are configured users
-      users &&
-      //the provided auth matches one of the users
-      users.find(user => {
-        let isAuthorized = user.user == auth.name &&
-                          (options.useEncryptedPasswords ? bcrypt.compareSync(auth.pass, user.pass) : user.pass == auth.pass);
-        if (isAuthorized) {
-          // User restricted apps
-          appsUserHasAccess = user.apps
-        }
-
-        return isAuthorized
-      });
+    let Authentication = require('./Authentication');
+    const authInstance = new Authentication(users, useEncryptedPasswords);
+    const authentication = authInstance.authenticate(auth);
+    
+    const successfulAuth = authentication.isAuthenticated;
+    const appsUserHasAccess = authentication.appsUserHasAccessTo;
 
     if (successfulAuth) {
-      if(appsUserHasAccess) {
+      if (appsUserHasAccess) {
         // Restric access to apps defined in user dictionary
         // If they didn't supply any app id, user will access all apps
         response.apps = response.apps.filter(function (app) {

--- a/README.md
+++ b/README.md
@@ -231,13 +231,11 @@ You can configure your dashboard for Basic Authentication by adding usernames an
       "pass":"pass"
     }
   ],
-  "options": {
-    "useEncryptedPasswords": true | false
-  }
+  "useEncryptedPasswords": true | false
 }
 ```
 
-You can store the password in either `plain text` or `bcrypt` formats. To use the `bcrypt` format, you must set the config `options.useEncryptedPasswords` parameter to `true`.
+You can store the password in either `plain text` or `bcrypt` formats. To use the `bcrypt` format, you must set the config `useEncryptedPasswords` parameter to `true`.
 You can encrypt the password using any online bcrypt tool e.g. [https://www.bcrypt-generator.com](https://www.bcrypt-generator.com).
 
 ### Separating App Access Based on User Identity

--- a/README.md
+++ b/README.md
@@ -230,11 +230,15 @@ You can configure your dashboard for Basic Authentication by adding usernames an
       "user":"user2",
       "pass":"pass"
     }
-  ]
+  ],
+  "options": {
+    "useEncryptedPasswords": true | false
+  }
 }
 ```
 
-You can store the password in either `plain text` or `bcrypt` formats. You can encrypt the password using any online bcrypt tool e.g. [https://www.bcrypt-generator.com](https://www.bcrypt-generator.com).
+You can store the password in either `plain text` or `bcrypt` formats. To use the `bcrypt` format, you must set the config `options.useEncryptedPasswords` parameter to `true`.
+You can encrypt the password using any online bcrypt tool e.g. [https://www.bcrypt-generator.com](https://www.bcrypt-generator.com).
 
 ### Separating App Access Based on User Identity
 If you have configured your dashboard to manage multiple applications, you can restrict the management of apps based on user identity.

--- a/src/lib/tests/Authentication.test.js
+++ b/src/lib/tests/Authentication.test.js
@@ -41,6 +41,18 @@ function createAuthenticationResult(isAuthenticated, appsUserHasAccessTo) {
 }
 
 describe('Authentication', () => {
+  it('does not authenticate with no users', () => {
+    let authentication = new Authentication(null, false);
+    expect(authentication.authenticate({name: 'parse.dashboard', pass: 'abc123'}))
+      .toEqual(createAuthenticationResult(false, null));
+  });
+
+  it('does not authenticate with no auth', () => {
+    let authentication = new Authentication(unencryptedUsers, false);
+    expect(authentication.authenticate(null))
+      .toEqual(createAuthenticationResult(false, null));
+  });
+
   it('does not authenticate invalid user', () => {
     let authentication = new Authentication(unencryptedUsers, false);
     expect(authentication.authenticate({name: 'parse.invalid', pass: 'abc123'}))

--- a/src/lib/tests/Authentication.test.js
+++ b/src/lib/tests/Authentication.test.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../../../Parse-Dashboard/Authentication.js');
+jest.dontMock('bcryptjs');
+
+const Authentication = require('../../../Parse-Dashboard/Authentication');
+const apps = [{appId: 'test123'}, {appId: 'test789'}];
+const unencryptedUsers = [
+  {
+    user: 'parse.dashboard',
+    pass: 'abc123'
+  },
+  {
+    user: 'parse.apps',
+    pass: 'xyz789',
+    apps: apps
+  }
+];
+const encryptedUsers = [
+  {
+    user: 'parse.dashboard',
+    pass: '$2a$08$w92YfzwkhB3WGFTBjHwZLO2tSwNIS2rX0qQER.TF8izEzWF5M.U8S'
+  },
+  {
+    user: 'parse.apps',
+    pass: '$2a$08$B666bpJqE9v/R5KNbgfOMOjycvHzv6zWs0sGky/QuBZb4HY0M6LE2',
+    apps: apps
+  }
+]
+
+function createAuthenticationResult(isAuthenticated, appsUserHasAccessTo) {
+  return {
+    isAuthenticated,
+    appsUserHasAccessTo
+  }
+}
+
+describe('Authentication', () => {
+  it('does not authenticate invalid user', () => {
+    let authentication = new Authentication(unencryptedUsers, false);
+    expect(authentication.authenticate({name: 'parse.invalid', pass: 'abc123'}))
+      .toEqual(createAuthenticationResult(false, null));
+  });
+
+  it('does not authenticate valid user with invalid unencrypted password', () => {
+    let authentication = new Authentication(unencryptedUsers, false);
+    expect(authentication.authenticate({name: 'parse.dashboard', pass: 'xyz789'}))
+      .toEqual(createAuthenticationResult(false, null));
+  });
+
+  it('authenticates valid user with valid unencrypted password', () => {
+    let authentication = new Authentication(unencryptedUsers, false);
+    expect(authentication.authenticate({name: 'parse.dashboard', pass: 'abc123'}))
+      .toEqual(createAuthenticationResult(true, null));
+  });
+
+  it('returns apps if valid user', () => {
+    let authentication = new Authentication(unencryptedUsers, false);
+    expect(authentication.authenticate({name: 'parse.apps', pass: 'xyz789'}))
+      .toEqual(createAuthenticationResult(true, apps));
+  });
+
+  it('authenticates valid user with valid encrypted password', () => {
+    let authentication = new Authentication(encryptedUsers, true);
+    expect(authentication.authenticate({name: 'parse.dashboard', pass: 'abc123'}))
+      .toEqual(createAuthenticationResult(true, null));
+  });
+
+  it('does not authenticate valid user with invalid encrypted password', () => {
+    let authentication = new Authentication(encryptedUsers, true);
+    expect(authentication.authenticate({name: 'parse.dashboard', pass: 'xyz789'}))
+      .toEqual(createAuthenticationResult(false, null));
+  });
+});


### PR DESCRIPTION
Discovered that my previous encrypted password implementation allowed the user to type the hash and be authenticated. I feel like that isn't going to be expected, so, I added an options config option to enable encrypted passwords.