### PR TITLE
Added add row button to data browser toolbar.

### DIFF
--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -1,3 +1,4 @@
+"use strict";
 function Authentication(validUsers, useEncryptedPasswords) {
     this.validUsers = validUsers;
     this.useEncryptedPasswords = useEncryptedPasswords || false;
@@ -21,13 +22,13 @@ Authentication.prototype.authenticate = function (userToTest) {
         appsUserHasAccessTo = user.apps || null;
       }
 
-      return isAuthenticated
+      return isAuthenticated;
     }) ? true : false;
   
   return {
     isAuthenticated,
     appsUserHasAccessTo
-  }
-}
+  };
+};
 
 module.exports = Authentication;

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -128,6 +128,11 @@ let BrowserToolbar = ({
       subsection={subsection}
       details={details.join(' \u2022 ')}
     >
+      <a className={styles.toolbarButton} onClick={onAddRow}>
+        <Icon name='plus-solid' width={14} height={14} />
+        <span>Add Row</span>
+      </a>
+      <div className={styles.toolbarSeparator} />
       <a className={styles.toolbarButton} onClick={onRefresh}>
         <Icon name='refresh-solid' width={14} height={14} />
         <span>Refresh</span>


### PR DESCRIPTION
![screenshot](https://cloud.githubusercontent.com/assets/5043576/18033303/f1095cce-6d20-11e6-9408-b51c33745105.jpg)

I added a shortcut to add a row to the data browser in the toolbar header. It might seem redundant, but it's easier to get to than the one in the Edit menu, and the one at the bottom can be too far down on long lists. 