### PR TITLE
Fix CLP documentation link URL

### DIFF
--- a/src/dashboard/Data/Browser/SecurityDialog.react.js
+++ b/src/dashboard/Data/Browser/SecurityDialog.react.js
@@ -55,7 +55,7 @@ export default class SecurityDialog extends React.Component {
           enablePointerPermissions={parseServerSupportsPointerPermissions}
           advanced={true}
           confirmText='Save CLP'
-          details={<a href='https://parse.com/docs/ios/guide#security-class-level-permissions'>Learn more about CLPs and app security</a>}
+          details={<a target="_blank" href='http://parseplatform.github.io/docs/ios/guide/#security'>Learn more about CLPs and app security</a>}
           permissions={this.props.perms}
           validateEntry={entry => validateEntry(this.props.userPointers, entry, parseServerSupportsPointerPermissions)}
           onCancel={() => {


### PR DESCRIPTION
Two fixes for the "Learn more about CLPs and app security" link from Edit Class Level Permissions dialogue.

- Fix href to point to github instead of parse.com
- Fix the link not opening a new tab