### PR TITLE
Added support for trusting proxies w/ HTTPS

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -74,7 +74,7 @@ module.exports = function(config, allowInsecureHTTP) {
       req.connection.remoteAddress === '127.0.0.1' ||
       req.connection.remoteAddress === '::ffff:127.0.0.1' ||
       req.connection.remoteAddress === '::1';
-    if (!requestIsLocal && !req.secure && !allowInsecureHTTP) {
+    if (!requestIsLocal && !req.secure && req.header('x-forwarded-proto') != 'https' && !allowInsecureHTTP) {
       //Disallow HTTP requests except on localhost, to prevent the master key from being transmitted in cleartext
       return res.send({ success: false, error: 'Parse Dashboard can only be remotely accessed via HTTPS' });
     }

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -48,13 +48,13 @@ function checkIfIconsExistForApps(apps, iconsFolder) {
   }
 }
 
-module.exports = function(config, allowInsecureHTTP, trustProxy) {
+module.exports = function(config, allowInsecureHTTP) {
   var app = express();
   // Serve public files.
   app.use(express.static(path.join(__dirname,'public')));
 
   // Allow setting via middleware
-  if (trustProxy && app.disabled('trust proxy')) {
+  if (config.trustProxy && app.disabled('trust proxy')) {
     app.enable('trust proxy');
   }
 

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -48,10 +48,15 @@ function checkIfIconsExistForApps(apps, iconsFolder) {
   }
 }
 
-module.exports = function(config, allowInsecureHTTP) {
+module.exports = function(config, allowInsecureHTTP, trustProxy) {
   var app = express();
   // Serve public files.
   app.use(express.static(path.join(__dirname,'public')));
+
+  // Allow setting via middleware
+  if (trustProxy && app.disabled('trust proxy')) {
+    app.enable('trust proxy');
+  }
 
   // Serve the configuration.
   app.get('/parse-dashboard-config.json', function(req, res) {

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -74,7 +74,7 @@ module.exports = function(config, allowInsecureHTTP) {
       req.connection.remoteAddress === '127.0.0.1' ||
       req.connection.remoteAddress === '::ffff:127.0.0.1' ||
       req.connection.remoteAddress === '::1';
-    if (!requestIsLocal && !req.secure && req.header('x-forwarded-proto') != 'https' && !allowInsecureHTTP) {
+    if (!requestIsLocal && !req.secure && !allowInsecureHTTP) {
       //Disallow HTTP requests except on localhost, to prevent the master key from being transmitted in cleartext
       return res.send({ success: false, error: 'Parse Dashboard can only be remotely accessed via HTTPS' });
     }

--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -24,6 +24,7 @@ program.option('--mountPath [mountPath]', 'the mount path to run parse-dashboard
 program.option('--allowInsecureHTTP [allowInsecureHTTP]', 'set this flag when you are running the dashboard behind an HTTPS load balancer or proxy with early SSL termination.');
 program.option('--sslKey [sslKey]', 'the path to the SSL private key.');
 program.option('--sslCert [sslCert]', 'the path to the SSL certificate.');
+program.option('--trustProxy [trustProxy]', 'set this flag when you are behind a front-facing proxy, such as when hosting on Heroku.  Uses X-Forwarded-* headers to determine the client\'s connection and IP address.');
 
 program.parse(process.argv);
 
@@ -31,6 +32,7 @@ const host = program.host || process.env.HOST || '0.0.0.0';
 const port = program.port || process.env.PORT || 4040;
 const mountPath = program.mountPath || process.env.MOUNT_PATH || '/';
 const allowInsecureHTTP = program.allowInsecureHTTP || process.env.PARSE_DASHBOARD_ALLOW_INSECURE_HTTP;
+const trustProxy = program.trustProxy || process.env.PARSE_DASHBOARD_TRUST_PROXY;
 
 let explicitConfigFileProvided = !!program.config;
 let configFile = null;
@@ -105,7 +107,7 @@ p.then(config => {
 
   const app = express();
 
-  if (allowInsecureHTTP) app.enable('trust proxy');
+  if (allowInsecureHTTP || trustProxy) app.enable('trust proxy');
   app.use(mountPath, parseDashboard(config.data, allowInsecureHTTP));
   if(!configSSLKey || !configSSLCert){
     // Start the server.

--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -108,7 +108,7 @@ p.then(config => {
   const app = express();
 
   if (allowInsecureHTTP || trustProxy) app.enable('trust proxy');
-  app.use(mountPath, parseDashboard(config.data, allowInsecureHTTP));
+  app.use(mountPath, parseDashboard(config.data, allowInsecureHTTP, trustProxy));
   if(!configSSLKey || !configSSLCert){
     // Start the server.
     const server = app.listen(port, host, function () {

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ In order to securely deploy the dashboard without leaking your apps master key, 
 
 The deployed dashboard detects if you are using a secure connection. If you are deploying the dashboard behind a load balancer or proxy that does early SSL termination, then the app won't be able to detect that the connection is secure. In this case, you can start the dashboard with the `--allowInsecureHTTP=1` option. You will then be responsible for ensureing that your proxy or load balancer only allows HTTPS.
 
-Alternatively, if you are behind a front-facing proxy and want to rely on the X-Forwarded-* headers for the client's connection and IP address, you can start the dashboard with the  `--trustProxy=1` option (or PARSE_DASHBOARD_TRUST_PROXY config var).  This is useful for hosting on services like Heroku, where you trust the provided proxy headers.  For Heroku in particular, setting this option allows the dashboard to correctly determine whether you're using HTTP or HTTPS.  You can also turn on this setting when using the dashboard as [express](https://github.com/expressjs/express) middleware:
+Alternatively, if you are behind a front-facing proxy and want to rely on the X-Forwarded-* headers for the client's connection and IP address, you can start the dashboard with the  `--trustProxy=1` option (or set the PARSE_DASHBOARD_TRUST_PROXY config var to 1).  This is useful for hosting on services like Heroku, where you can trust the provided proxy headers.  For Heroku in particular, setting this option allows the dashboard to correctly determine whether you're using HTTP or HTTPS.  You can also turn on this setting when using the dashboard as [express](https://github.com/expressjs/express) middleware:
 
 ```
 var insecureHTTP = false;

--- a/README.md
+++ b/README.md
@@ -180,6 +180,25 @@ In order to securely deploy the dashboard without leaking your apps master key, 
 
 The deployed dashboard detects if you are using a secure connection. If you are deploying the dashboard behind a load balancer or proxy that does early SSL termination, then the app won't be able to detect that the connection is secure. In this case, you can start the dashboard with the `--allowInsecureHTTP=1` option. You will then be responsible for ensureing that your proxy or load balancer only allows HTTPS.
 
+Alternatively, if you are behind a front-facing proxy and want to rely on the X-Forwarded-* headers for the client's connection and IP address, you can start the dashboard with the  `--trustProxy=1` option (or PARSE_DASHBOARD_TRUST_PROXY config var).  This is useful for hosting on services like Heroku, where you trust the provided proxy headers.  For Heroku in particular, setting this option allows the dashboard to correctly determine whether you're using HTTP or HTTPS.  You can also turn on this setting when using the dashboard as [express](https://github.com/expressjs/express) middleware:
+
+```
+var insecureHTTP = false;
+var trustProxy = true;
+var dashboard = new ParseDashboard({
+  "apps": [
+    {
+      "serverURL": "http://localhost:1337/parse",
+      "appId": "myAppId",
+      "masterKey": "myMasterKey",
+      "appName": "MyApp"
+    }
+  ]
+}, insecureHTTP, trustProxy);
+```
+
+
+
 ### Configuring Basic Authentication
 You can configure your dashboard for Basic Authentication by adding usernames and passwords your `parse-dashboard-config.json` configuration file:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can also define each configuration option individually.
 HOST: "0.0.0.0"
 PORT: "4040"
 MOUNT_PATH: "/"
-PARSE_DASHBOARD_ALLOW_INSECURE_HTTP: undefined // Or "1" to allow http
+PARSE_DASHBOARD_TRUST_PROXY: undefined // Or "1" to trust connection info from a proxy's X-Forwarded-* headers
 PARSE_DASHBOARD_SERVER_URL: "http://localhost:1337/parse"
 PARSE_DASHBOARD_MASTER_KEY: "myMasterKey"
 PARSE_DASHBOARD_APP_ID: "myAppId"
@@ -213,12 +213,9 @@ Make sure the server URLs for your apps can be accessed by your browser. If you 
 ## Security Considerations
 In order to securely deploy the dashboard without leaking your apps master key, you will need to use HTTPS and Basic Authentication.
 
-The deployed dashboard detects if you are using a secure connection. If you are deploying the dashboard behind a load balancer or proxy that does early SSL termination, then the app won't be able to detect that the connection is secure. In this case, you can start the dashboard with the `--allowInsecureHTTP=1` option. You will then be responsible for ensureing that your proxy or load balancer only allows HTTPS.
-
-Alternatively, if you are behind a front-facing proxy and want to rely on the X-Forwarded-* headers for the client's connection and IP address, you can start the dashboard with the  `--trustProxy=1` option (or set the PARSE_DASHBOARD_TRUST_PROXY config var to 1).  This is useful for hosting on services like Heroku, where you can trust the provided proxy headers.  For Heroku in particular, setting this option allows the dashboard to correctly determine whether you're using HTTP or HTTPS.  You can also turn on this setting when using the dashboard as [express](https://github.com/expressjs/express) middleware:
+The deployed dashboard detects if you are using a secure connection. If you are deploying the dashboard behind a load balancer or front-facing proxy, then the app won't be able to detect that the connection is secure. In this case, you can start the dashboard with the `--trustProxy=1` option (or set the PARSE_DASHBOARD_TRUST_PROXY config var to 1) to rely on the X-Forwarded-* headers for the client's connection security.  This is useful for hosting on services like Heroku, where you can trust the provided proxy headers to correctly determine whether you're using HTTP or HTTPS.  You can also turn on this setting when using the dashboard as [express](https://github.com/expressjs/express) middleware:
 
 ```
-var insecureHTTP = false;
 var trustProxy = true;
 var dashboard = new ParseDashboard({
   "apps": [
@@ -228,8 +225,9 @@ var dashboard = new ParseDashboard({
       "masterKey": "myMasterKey",
       "appName": "MyApp"
     }
-  ]
-}, insecureHTTP, trustProxy);
+  ],
+  "trustProxy": 1
+});
 ```
 
 


### PR DESCRIPTION
(Thanks to http://jaketrent.com/post/https-redirect-node-heroku/)
When hosting on Heroku, it turns out the request.secure will always be false, even if the client requests over HTTPS. Instead, Heroku adds an HTTP header 'x-forwarded-proto' specifying the protocol used ('http' or 'https'). For those on Heroku, this additional check will allow the HTTPs check to work. For those not on Heroku (where this header doesn't exist), it won't do anything.

A followup PR to https://github.com/ParsePlatform/parse-dashboard/pull/454.