### PR TITLE
Adds an "ends with" filter for string queries

### DIFF
--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -45,6 +45,9 @@ export const Constraints = {
   starts: {
     name: 'starts with',
   },
+  ends: {
+    name: 'ends with',
+  },
   before: {
     name: 'is before',
     field: 'Date',
@@ -89,7 +92,7 @@ export const FieldConstraints = {
   'Pointer': [ 'exists', 'dne', 'eq', 'neq'],
   'Boolean': [ 'exists', 'dne', 'eq' ],
   'Number': [ 'exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte' ],
-  'String': [ 'exists', 'dne', 'eq', 'neq', 'starts' ],
+  'String': [ 'exists', 'dne', 'eq', 'neq', 'starts', 'ends' ],
   'Date': [ 'exists', 'dne', 'before', 'after' ],
   'Array': [
     'exists',

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -50,6 +50,9 @@ function addConstraint(query, filter) {
     case 'starts':
       query.startsWith(filter.get('field'), filter.get('compareTo'));
       break;
+    case 'ends':
+      query.endsWith(filter.get('field'), filter.get('compareTo'));
+      break;
     case 'before':
       query.lessThan(filter.get('field'), filter.get('compareTo'));
       break;


### PR DESCRIPTION
This is a simple addition to the existing string filters in the Parse dashboard.

<img width="600" alt="screen shot 2016-09-22 at 10 30 03" src="https://cloud.githubusercontent.com/assets/13404759/18741663/9fdd66c6-80b0-11e6-9768-695549ef9d94.png">
