### PR TITLE
Fix calendar month/current selection and clicking

### DIFF
--- a/src/components/Calendar/Calendar.react.js
+++ b/src/components/Calendar/Calendar.react.js
@@ -22,14 +22,14 @@ export default class Calendar extends React.Component {
     super();
     let now = props.value || new Date();
     this.state = {
-      currentMonth: new Date(now[getDateMethod(props.local, 'getFullYear')](), now[getDateMethod(props.local, 'getMonth')](), 1)
+      currentMonth: new Date(Date.UTC(now[getDateMethod(props.local, 'getFullYear')](), now[getDateMethod(props.local, 'getMonth')](), 1))
     };
   }
 
   componentWillReceiveProps(props) {
     if (props.value) {
       this.setState({
-        currentMonth: new Date(props.value[getDateMethod(props.local, 'getFullYear')](), props.value[getDateMethod(props.local, 'getMonth')](), 1)
+        currentMonth: new Date(Date.UTC(props.value[getDateMethod(props.local, 'getFullYear')](), props.value[getDateMethod(props.local, 'getMonth')](), 1))
       });
     }
   }
@@ -51,7 +51,7 @@ export default class Calendar extends React.Component {
       <div className={styles.month}>
         <a href='javascript:;' role='button' onClick={this.handlePrev.bind(this)} />
         <a href='javascript:;' role='button' onClick={this.handleNext.bind(this)} />
-        <div>{getMonth(this.state.currentMonth[getDateMethod(this.props.local, 'getMonth')]()) + ' ' + this.state.currentMonth[getDateMethod(this.props.local, 'getFullYear')]()}</div>
+        <div>{getMonth(this.state.currentMonth.getMonth()) + ' ' + this.state.currentMonth.getFullYear()}</div>
       </div>
     );
   }
@@ -67,10 +67,10 @@ export default class Calendar extends React.Component {
   renderDays() {
     let isValueMonth = (
       this.props.value &&
-      this.props.value[getDateMethod(this.props.local, 'getFullYear')]() === this.state.currentMonth[getDateMethod(this.props.local, 'getFullYear')]() &&
-      this.props.value[getDateMethod(this.props.local, 'getMonth')]() === this.state.currentMonth[getDateMethod(this.props.local, 'getMonth')]()
+      this.props.value[getDateMethod(this.props.local, 'getFullYear')]() === this.state.currentMonth.getFullYear() &&
+      this.props.value[getDateMethod(this.props.local, 'getMonth')]() === this.state.currentMonth.getMonth()
     );
-    let offset = this.state.currentMonth[getDateMethod(this.props.local, 'getDay')]();
+    let offset = this.state.currentMonth.getDay();
     let days = daysInMonth(this.state.currentMonth);
     let labels = [];
     for (let i = 0; i < offset; i++) {
@@ -81,7 +81,7 @@ export default class Calendar extends React.Component {
       let className = isSelected ? styles.selected : '';
       let onChange = this.props.onChange.bind(
         null,
-        new Date(this.state.currentMonth[getDateMethod(this.props.local, 'getFullYear')](), this.state.currentMonth[getDateMethod(this.props.local, 'getMonth')](), i)
+        new Date(Date.UTC(this.state.currentMonth.getFullYear(), this.state.currentMonth.getMonth(), i))
       );
       labels.push(
         <a href='javascript:;' role='button' key={'day' + i} className={className} onClick={onChange}>{i}</a>

--- a/src/components/Calendar/Calendar.react.js
+++ b/src/components/Calendar/Calendar.react.js
@@ -22,14 +22,14 @@ export default class Calendar extends React.Component {
     super();
     let now = props.value || new Date();
     this.state = {
-      currentMonth: new Date(Date.UTC(now[getDateMethod(props.local, 'getFullYear')](), now[getDateMethod(props.local, 'getMonth')](), 1))
+      currentMonth: new Date(now[getDateMethod(props.local, 'getFullYear')](), now[getDateMethod(props.local, 'getMonth')](), 1)
     };
   }
 
   componentWillReceiveProps(props) {
     if (props.value) {
       this.setState({
-        currentMonth: new Date(Date.UTC(props.value[getDateMethod(props.local, 'getFullYear')](), props.value[getDateMethod(props.local, 'getMonth')](), 1))
+        currentMonth: new Date(props.value[getDateMethod(props.local, 'getFullYear')](), props.value[getDateMethod(props.local, 'getMonth')](), 1)
       });
     }
   }
@@ -81,7 +81,9 @@ export default class Calendar extends React.Component {
       let className = isSelected ? styles.selected : '';
       let onChange = this.props.onChange.bind(
         null,
-        new Date(Date.UTC(this.state.currentMonth.getFullYear(), this.state.currentMonth.getMonth(), i))
+        this.props.local ?
+          new Date(this.state.currentMonth.getFullYear(), this.state.currentMonth.getMonth(), i) :
+          new Date(Date.UTC(this.state.currentMonth.getFullYear(), this.state.currentMonth.getMonth(), i))
       );
       labels.push(
         <a href='javascript:;' role='button' key={'day' + i} className={className} onClick={onChange}>{i}</a>


### PR DESCRIPTION
Code in DateUtils uses local time (e.g. getMonth() instead of getUTCMonth() etc.) so for compatibility state.currentMonth is also now considered local time.

props.local is used in only 2 places:
1. When constructing state.currentMonth to decide if props.value is in local or UTC time
2. When sending an outgoing onChange event to convert currentMonth back to local or UTC time

There is no code path where props.local is true so this has not been tested. I can't think why this would be required so would like to remove in a non-bugfix PR.

Have tested in timezones UTC+1, UTC-12, UTC+14 (in which case local time was one day after UTC)