### PR TITLE
Updated to pass masterKey for Config get request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT RELEASE
 
 * Fix: Can't send push to specific user (#561)
+* Fix: Config FETCH results in 401 (#339), thanks to [Matt Simms](https://github.com/brndmg)
 
 ### 1.0.19
 

--- a/src/lib/stores/ConfigStore.js
+++ b/src/lib/stores/ConfigStore.js
@@ -22,8 +22,13 @@ function ConfigStore(state, action) {
   action.app.setParseKeys();
   switch (action.type) {
     case ActionTypes.FETCH:
-      return Parse.Config.get().then(({ attributes }) => {
-        return Map({ lastFetch: new Date(), params: Map(attributes) });
+      return Parse._request(
+        'GET',
+        'config',
+        {},
+        { useMasterKey: true }
+      ).then((result) => {
+        return Map({ lastFetch: new Date(), params: Map(result.params) });
       });
     case ActionTypes.SET:
       return Parse._request(


### PR DESCRIPTION
I believe this will resolve #339.  When the masterKey is not being passed on the FETCH, then the server is returning a 401.

I had the same issue with version 1.0.19 of the dashboard and 2.2.24 of the server.