### PR TITLE
Check usernameOnly parameter in passwordMatches

### DIFF
--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -88,7 +88,7 @@ function authenticate(userToTest, usernameOnly) {
     this.validUsers.find(user => {
       let isAuthenticated = false;
       let usernameMatches = userToTest.name == user.user;
-      let passwordMatches = this.useEncryptedPasswords ? bcrypt.compareSync(userToTest.pass, user.pass) : userToTest.pass == user.pass;
+      let passwordMatches = this.useEncryptedPasswords && !usernameOnly ? bcrypt.compareSync(userToTest.pass, user.pass) : userToTest.pass == user.pass;
       if (usernameMatches && (usernameOnly || passwordMatches)) {
         isAuthenticated = true;
         matchingUsername = user.user;

--- a/src/lib/tests/Authentication.test.js
+++ b/src/lib/tests/Authentication.test.js
@@ -101,4 +101,10 @@ describe('Authentication', () => {
     expect(authentication.authenticate({name: 'parse.dashboard'}))
       .toEqual(createAuthenticationResult(false, null, null));
   });
+
+  it('authenticates valid user with valid username and usernameOnly and encrypted password', () => {
+    let authentication = new Authentication(encryptedUsers, true);
+    expect(authentication.authenticate({name: 'parse.dashboard'}, true))
+      .toEqual(createAuthenticationResult(true, 'parse.dashboard', null));
+  });
 });


### PR DESCRIPTION
When authenticating to dashboard using encrypted passwords, bcrypt throws an error in the authenticate function that userToTest.pass is undefined. This happens when the userToTest object does not contain a password, which happens every time deserializeUser is called. The solution is to check the usernameOnly flag when initializing passwordMatches to avoid passing an undefined value to bcrypt.