### PR TITLE
Fix fetching jobs list with master key

### DIFF
--- a/src/lib/stores/JobsStore.js
+++ b/src/lib/stores/JobsStore.js
@@ -30,7 +30,7 @@ function JobsStore(state, action) {
         return Parse.Promise.as(state);
       }
       path = `cloud_code/jobs?per_page=50`;
-      return Parse._request('GET', path).then((results) => {
+      return Parse._request('GET', path, {}, { useMasterKey: true}).then((results) => {
         return Map({ lastFetch: new Date(), jobs: List(results) });
       });
     case ActionTypes.CREATE:


### PR DESCRIPTION
Without the master key present, fetching the jobs list from `/cloud_code/jobs` fails with 403 unauthorized.