### PR TITLE
Don’t call unsupported endpoints in Parse Server

### DIFF
--- a/src/dashboard/Data/Jobs/Jobs.react.js
+++ b/src/dashboard/Data/Jobs/Jobs.react.js
@@ -120,7 +120,7 @@ export default class Jobs extends TableView {
   renderRow(data) {
     if (this.props.params.section === 'all') {
       return (
-        <tr key={data.objectId}>
+        <tr key={data.jobName}>
           <td style={{width: '60%'}}>{data.jobName}</td>
           <td className={styles.buttonCell}>
             <RunNowButton job={data} width={'100px'} />

--- a/src/dashboard/Data/Jobs/JobsData.react.js
+++ b/src/dashboard/Data/Jobs/JobsData.react.js
@@ -19,6 +19,10 @@ export default class JobsData extends React.Component {
     };
   }
 
+  // As parse-server doesn't support (yet?) these features, we are disabling
+  // these calls in the meantime.
+
+  /*
   fetchRelease(app) {
     app.getLatestRelease().then(
       ({ release }) => this.setState({ release }),
@@ -39,17 +43,18 @@ export default class JobsData extends React.Component {
       }, () => this.setState({ jobs: [], inUse: [] })
     );
   }
+  */
 
   componentDidMount() {
-    this.fetchJobs(this.context.currentApp);
-    this.fetchRelease(this.context.currentApp);
+    // this.fetchJobs(this.context.currentApp);
+    // this.fetchRelease(this.context.currentApp);
   }
 
   componentWillReceiveProps(props, context) {
     if (this.context !== context) {
       this.setState({ release: undefined, jobs: undefined, inUse: undefined });
-      this.fetchJobs(context.currentApp);
-      this.fetchRelease(context.currentApp);
+      // this.fetchJobs(context.currentApp);
+      // this.fetchRelease(context.currentApp);
     }
   }
 

--- a/src/dashboard/Data/Logs/Logs.react.js
+++ b/src/dashboard/Data/Logs/Logs.react.js
@@ -35,13 +35,13 @@ export default class Logs extends DashboardView {
 
   componentDidMount() {
     this.fetchLogs(this.context.currentApp, this.props.params.type);
-    this.fetchRelease(this.context.currentApp);
+    // this.fetchRelease(this.context.currentApp);
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
     if (this.context !== nextContext) {
       this.fetchLogs(nextContext.currentApp, nextProps.params.type);
-      this.fetchRelease(nextContext.currentApp);
+      // this.fetchRelease(nextContext.currentApp);
     }
   }
 
@@ -53,12 +53,17 @@ export default class Logs extends DashboardView {
     );
   }
 
+  // As parse-server doesn't support (yet?) versioning, we are disabling
+  // this call in the meantime.
+
+  /*
   fetchRelease(app) {
     app.getLatestRelease().then(
       ({ release }) => this.setState({ release }),
       () => this.setState({ release: null })
     );
   }
+  */
 
   renderSidebar() {
     let current = this.props.params.type || '';
@@ -100,6 +105,7 @@ export default class Logs extends DashboardView {
         <div className={styles.content}>
           <LogView>
             {this.state.logs.map(({ message, timestamp }) => <LogViewEntry
+              key={timestamp}
               text={message}
               timestamp={timestamp} />)}
           </LogView>


### PR DESCRIPTION
Also, this PR fixes 2 React warnings related to not setting a key in a few components (See Logs.react.js and Jobs.react.js)

Fixes #295