### PR TITLE
Fix display of ParseFile in Config

### DIFF
--- a/src/components/FileInput/FileInput.react.js
+++ b/src/components/FileInput/FileInput.react.js
@@ -40,7 +40,7 @@ export default class FileInput extends React.Component {
   render() {
     let inputProps = {
       type: 'file',
-      value: null,
+      value: '',
       disabled: this.props.disabled,
       onChange: this.handleChange.bind(this),
     };
@@ -55,7 +55,7 @@ export default class FileInput extends React.Component {
     if (label) {
       buttonStyles.push(styles.withLabel)
     }
-    
+
     return (
       <div className={styles.input}>
         <div className={buttonStyles.join(' ')}>

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -72,6 +72,7 @@ class Config extends TableView {
     let value = data.value;
     let modalValue = value;
     let type = typeof value;
+
     if (type === 'object') {
       if (isDate(value)) {
         type = 'Date';
@@ -84,9 +85,9 @@ class Config extends TableView {
         type = 'GeoPoint';
         value = `(${value.latitude}, ${value.longitude})`;
         modalValue = data.value.toJSON();
-      } else if (value instanceof Parse.File) {
+      } else if (data.value instanceof Parse.File) {
         type = 'File';
-        value = <a target='_blank' href={value.url()}>Open in new window</a>;
+        value = <a target='_blank' href={data.value.url()}>Open in new window</a>;
       } else {
         type = 'Object';
         value = JSON.stringify(value);
@@ -105,11 +106,19 @@ class Config extends TableView {
       modalValue: modalValue
     });
     let columnStyle = { width: '30%', cursor: 'pointer' };
+
+    let openModalValueColumn = () => {
+      if (data.value instanceof Parse.File) {
+        return
+      }
+      openModal()
+    }
+
     return (
       <tr key={data.param}>
         <td style={columnStyle} onClick={openModal}>{data.param}</td>
         <td style={columnStyle} onClick={openModal}>{type}</td>
-        <td style={columnStyle} onClick={openModal}>{value}</td>
+        <td style={columnStyle} onClick={openModalValueColumn}>{value}</td>
         <td style={{ textAlign: 'center' }}>
           <a onClick={this.deleteParam.bind(this, data.param)}>
             <Icon width={16} height={16} name='trash-solid' fill='#ff395e' />
@@ -145,7 +154,15 @@ class Config extends TableView {
       if (params) {
         data = [];
         params.forEach((value, param) => {
-          data.push({ param, value });
+          let type = typeof value;
+          if (type === 'object' && value.__type == 'File') {
+            value = Parse.File.fromJSON(value);
+          }
+          else if (type === 'object' && value.__type == 'GeoPoint') {
+            value = new Parse.GeoPoint(value);
+          }
+
+          data.push({ param: param, value: value })
         });
       }
     }


### PR DESCRIPTION
This PR fixes the display of `Parse.File`s  and GeoPoints in the Config section of the Dashboard.
Now that @flovilmart fixed saving Files to Config in Parse Server (ParsePlatform/parse-server#3457), this is the last bit to have it working in the dashboard.

### Before:
![captura de tela 2017-02-20 as 13 30 17](https://cloud.githubusercontent.com/assets/1164565/23123401/d9c50bd2-f770-11e6-916a-ef7be1241e59.png)

![captura de tela 2017-02-20 as 13 19 02](https://cloud.githubusercontent.com/assets/1164565/23123187/19612704-f770-11e6-9c28-44aeca3c97ec.png)

### After
<img width="973" alt="captura de tela 2017-02-19 as 23 51 24" src="https://cloud.githubusercontent.com/assets/1164565/23107619/04140356-f709-11e6-8df6-e4345bff6163.png">

![captura de tela 2017-02-20 as 13 19 08](https://cloud.githubusercontent.com/assets/1164565/23123204/26053798-f770-11e6-99b3-17f3d7b2e116.png)


@JeremyPlease @dvanwinkle @steven-supersolid if anyone of you could review, it would be great.